### PR TITLE
fixes #8 so we generate a new bash script which is ahead on the path so used by default if folks run "bash" on the supervisor; you can still run /bin/bash to really get onto the supervisor

### DIFF
--- a/ansible/ansible.go
+++ b/ansible/ansible.go
@@ -33,6 +33,10 @@ const (
 // EnvRC is the environment variable on a pod for the name of the ReplicationController
 	EnvRC = "GOSUPERVISE_RC"
 
+// EnvBash is the environment variable on a pod for the name of the bash script to generate on startup for
+// opening a remote shell
+	EnvBash = "GOSUPERVISE_BASH"
+
 // PlaybookVolumeMount is the volume mount point where the playbook is assumed to be in the supervisor pod
 	PlaybookVolumeMount = "/playbook"
 
@@ -254,6 +258,7 @@ func UpdateAnsibleRC(inventoryFile string, hosts string, c *client.Client, ns st
 	}
 	k8s.EnsureContainerHasEnvVar(container, EnvHosts, hosts)
 	k8s.EnsureContainerHasEnvVar(container, EnvRC, rcName)
+	k8s.EnsureContainerHasEnvVar(container, EnvBash, "/usr/local/bin/bash")
 	command := k8s.GetContainerEnvVar(container, EnvCommand)
 	if len(command) == 0 {
 		return nil, fmt.Errorf("No environemnt variable value defined for %s in ReplicationController YAML file %s", EnvCommand, rcFile)


### PR DESCRIPTION
fixes #8 so we generate a new bash script which is ahead on the path so used by default if folks run "bash" on the supervisor; you can still run /bin/bash to really get onto the supervisor
