### PR TITLE
Add a sample Dockerfile using scratch as base

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,0 +1,6 @@
+FROM scratch
+# Call 'make build-all' before building it
+ADD _dist/linux-amd64/kansible /
+# Image must be used with 2 arguments: HOSTS and COMMANDS
+# (they can't be added as environment since no shell is available)
+CMD [ "/kansible", "pod" ]


### PR DESCRIPTION
Some changes are required when creating the RC, though, since there is no way to provide envs as args when no shell is available.

Solutions:
- Add arguments to the RC definition
- Evaluate environment variables directly within the go supervisor
