### PR TITLE
Eval 'kansible pod' args for envs as well

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,6 +1,5 @@
 FROM scratch
 # Call 'make build-all' before building it
 ADD _dist/linux-amd64/kansible /
-# Image must be used with 2 arguments: HOSTS and COMMANDS
-# (they can't be added as environment since no shell is available)
-CMD [ "/kansible", "pod" ]
+# Variables are interpolated not by Docker but by kansible (they are transmitted literally)
+CMD [ "/kansible", "pod", "$KANSIBLE_HOSTS", "$KANSIBLE_COMMAND" ]

--- a/kansible.go
+++ b/kansible.go
@@ -232,18 +232,18 @@ func runAnsiblePod(c *cli.Context) {
 	if len(args) < 2 {
 		log.Die("Expected at least 2 arguments!")
 	}
-	hosts := args[0]
-	command := strings.Join(args[1:], " ")
+	hosts := os.ExpandEnv(args[0])
+	command := os.ExpandEnv(strings.Join(args[1:], " "))
 
 	log.Info("running command on a host from %s and command `%s`", hosts, command)
 
 	f := cmdutil.NewFactory(nil)
 	if f == nil {
-		log.Die("Failed to create Kuberentes client factory!")
+		log.Die("Failed to create Kubernetes client factory!")
 	}
 	kubeclient, _ := f.Client()
 	if kubeclient == nil {
-		log.Die("Failed to create Kuberentes client!")
+		log.Die("Failed to create Kubernetes client!")
 	}
 	ns, _, _ := f.DefaultNamespace()
 	if len(ns) == 0 {


### PR DESCRIPTION
This allows the usage of the binary in a context without a shell
