### PR TITLE
Add target 'docker-scratch' to Makefile

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,5 +1,5 @@
 FROM scratch
 # Call 'make build-all' before building it
-ADD _dist/linux-amd64/kansible /
+ADD bin/kansible-docker /kansible
 # Variables are interpolated not by Docker but by kansible (they are transmitted literally)
 CMD [ "/kansible", "pod", "$KANSIBLE_HOSTS", "$KANSIBLE_COMMAND" ]

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ test-style:
 		go vet github.com/fabric8io/kansible/$$i; \
 	done
 
+docker-scratch:
+	gox -verbose -ldflags "-X main.version=${VERSION}" -os="linux" -arch="amd64" \
+	   -output="bin/kansible-docker" .
+	docker build -f Dockerfile.scratch -t "fabric8/kansible:0.0.1-scratch"	.
+	docker tag -f "fabric8/kansible:0.0.1-scratch"	"fabric8/kansible:latest"
 
 release:
 	rm -rf build release && mkdir build release


### PR DESCRIPTION
The docker image works fine with kansible (and is only 28 MB in size)
