### PR TITLE
Final touches on the circleci build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
-  services:
-    - docker
+#  services:
+#    - docker
   environment:
     GO15VENDOREXPERIMENT: 1
     GOPATH: ${HOME}/kansible/gopath:${GOPATH}
@@ -16,11 +16,10 @@ dependencies:
   override:
     - go version
     - glide --version
-    - make bootstrap build test:
-        pwd: ../gopath/src/github.com/fabric8io/kansible
+    - make bootstrap build:
+        pwd: gopath/src/github.com/fabric8io/kansible
   cache_directories:
     - vendor
-
 
 test:
   override:


### PR DESCRIPTION
The build is working however should be replaced soon by our very own Jenkins CD.
The generation of a Docker image with push to Docker Hub is disabled to avoid conflicts with this Jenkins build.

Nevertheless this build highlights some important points when using go projects with circleci:
- Environments vars should be set in the 'environment' section of 'machine'
- The directory hierarchy must be carefully crafted: The "vendor" dir must lie within its proper place in a go-dir hierarchy, as well as the build directory itself. Therefore the symlinking
- The build must be performed from within the symlinked directory
- No gotools like 'golint' are installed (hence no 'make test')

And yes, sorry for all the noise.
