### PR TITLE
#3 properly forward ports by listening to 0.0.0.0 rather than just localhost. Also allow port forwarding to be disabled; e.g. for the 'bash' command to create a remote shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,16 @@ This defines the path where the bash script will be generated for running a remo
     oc exec -p mypodname bash
 ```
 
+#### KANSIBLE_PORT_FORWARD
+
+Allows port forwarding to be disabled. 
+
+```
+export KANSIBLE_PORT_FORWARD=false
+```
+
+This is mostly useful to allow the `bash` command within a pod to not also try to port forward as this will fail ;)
+
 ### SSH or WinRM
 
 The best way to configure if you want to connect via SSH for unix machines or WinRM for windows machines is via the Ansible Inventory.

--- a/ansible/ansible.go
+++ b/ansible/ansible.go
@@ -46,6 +46,9 @@ const (
 // EnvExportEnvVars is the space separated list of environment variables exported to the remote process
 	EnvExportEnvVars = "KANSIBLE_EXPORT_ENV_VARS"
 
+// EnvPortForward allows port forwarding to be disabled
+	EnvPortForward = "KANSIBLE_PORT_FORWARD"
+
 // EnvBash is the environment variable on a pod for the name of the bash script to generate on startup for
 // opening a remote shell
 	EnvBash = "KANSIBLE_BASH"
@@ -313,7 +316,7 @@ func forwardPorts(pod *api.Pod, hostEntry *HostEntry) error {
 			name := port.Name
 			portNum := port.ContainerPort
 			if portNum > 0 {
-				address := "localhost:" + strconv.Itoa(portNum)
+				address := "0.0.0.0:" + strconv.Itoa(portNum)
 				forwardAddress := host + ":" + strconv.Itoa(portNum)
 				err := forwardPortLoop(name, address, forwardAddress)
 				if err != nil {

--- a/cmds/pod.go
+++ b/cmds/pod.go
@@ -107,6 +107,6 @@ func generateBashScript(file string, connection string) error {
 	if connection == ansible.ConnectionWinRM {
 		shellCommand = "PowerShell"
 	}
-	text :=  "#!/bin/sh\n" + "echo opening shell on remote machine...\n" + "kansible pod appservers " + shellCommand + "\n";
+	text :=  "#!/bin/sh\n" + "echo opening shell on remote machine...\n" + "export KANSIBLE_PORT_FORWARD=false\n" + "kansible pod appservers " + shellCommand + "\n";
 	return ioutil.WriteFile(file, []byte(text), 0555)
 }


### PR DESCRIPTION
#3 properly forward ports by listening to 0.0.0.0 rather than just localhost. Also allow port forwarding to be disabled; e.g. for the 'bash' command to create a remote shell
