### PR TITLE
lets automatically add the preStop lifecycle hook to the RC to kill windows shells. fixes #74

### DIFF
--- a/ansible/ansible.go
+++ b/ansible/ansible.go
@@ -407,6 +407,8 @@ func UpdateKansibleRC(hostEntries []*HostEntry, hosts string, c *client.Client, 
 	if len(container.ImagePullPolicy) == 0 {
 		container.ImagePullPolicy = "IfNotPresent"
 	}
+	preStopCommands := []string{"kansible", "kill"}
+	k8s.EnsureContainerHasPreStopCommand(container, preStopCommands)
 	k8s.EnsureContainerHasEnvVar(container, EnvHosts, hosts)
 	k8s.EnsureContainerHasEnvVar(container, EnvRC, rcName)
 	k8s.EnsureContainerHasEnvVar(container, EnvBash, "/usr/local/bin/bash")

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -128,6 +128,23 @@ func EnsureContainerHasEnvVar(container *api.Container, name string, value strin
 	return false
 }
 
+
+// EnsureContainerHasPreStopCommand ensures that the given container has a `preStop` lifecycle hook
+// to invoke the given commands
+func EnsureContainerHasPreStopCommand(container *api.Container, commands []string) {
+	if container.Lifecycle == nil {
+		container.Lifecycle = &api.Lifecycle{}
+	}
+	lifecycle := container.Lifecycle
+	if lifecycle.PreStop == nil {
+		lifecycle.PreStop = &api.Handler{}
+	}
+	preStop := lifecycle.PreStop
+	preStop.Exec = &api.ExecAction{
+		Command: commands,
+	}
+}
+
 // EnsureContainerHasVolumeMount ensures that there is a volume mount of the given name with the given values
 // Returns true if there was already a volume mount
 func EnsureContainerHasVolumeMount(container *api.Container, name string, mountPath string) bool {


### PR DESCRIPTION
lets automatically add the preStop lifecycle hook to the RC to kill windows shells. fixes #74
