### PR TITLE
Use releases of github.com/Masterminds/semver when updating

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: 08c4918b31dccf72bd8c74d8129c35d5aa0dfcd609298b0f62b742470a02286b
+hash: d7ccefe1037b4bca599685cb815a780c0b849dfe5986b11470d5af2cfa988014
 updated: 2016-04-06T21:01:29.979529412+01:00
 imports:
 - name: bitbucket.org/ww/goautoneg

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,7 @@ package: github.com/fabric8io/gosupervise
 import:
 - package: github.com/Masterminds/vcs
 - package: github.com/Masterminds/semver
+  version: ^1.0.0
 - package: k8s.io/kubernetes
   version: v1.2.1
   subpackages:


### PR DESCRIPTION
When updating Glide use a 1.x release of semver.

For semver we are working on a 2.x release. Because of the major version bump it's worth using 1.x releases (which this will cause Glide to do). No 2.x release is out yet but we want to make sure any projects aren't impacted when it happens.

This update doesn't alter your pinned or vendored dependencies. When the next update happens the semver will use the latest 1.x release.
